### PR TITLE
feat: Add new setting showHideExcludedConfig.exclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,16 @@
 						"**/Thumbs.db"
 					],
 					"description": "If you dont want to change the status of some files you can add them here, they must be exactly as they appear in the files.exclude option. The files on this list will not be touched by this extension"
+				},
+				"showHideExcludedConfig.exclude": {
+					"order": 4,
+					"type": "array",
+					"properties": {
+						"type": "string",
+						"title": "Ignore this excludes"
+					},
+					"default": [],
+					"description": "Static exclude list used to generate files.exclude"
 				}
 			}
 		},

--- a/src/showHideExcludes.ts
+++ b/src/showHideExcludes.ts
@@ -124,6 +124,7 @@ export class ShowHideExcludes {
         this.updateStatusBar(status);
         vscode.commands.executeCommand('setContext', 'biati.excludedStatus', status);
 
+        // When hiding, store whether the user had workspace excludes defined
         const existingWorkspaceExcludes = this.hasWorkspaceExcludes();
         if (!existingWorkspaceExcludes) {
             this.storageSet('hadEmptyWorkspaceExcludes', true);
@@ -137,10 +138,9 @@ export class ShowHideExcludes {
 
 
     showExcludes(): void {
-        // When hiding, if the user had no workspace excludes then
+        // When showing, if the user had no workspace excludes then
         // simply delete the excludes from the workspace configuration
         if (this.storageGet('hadEmptyWorkspaceExcludes')) {
-            console.log('reset!')
             this.resetWorkspaceExcludes();
         } else {
             this.updateExcludes(this.updateExcludesValue('show'));

--- a/src/showHideExcludes.ts
+++ b/src/showHideExcludes.ts
@@ -42,12 +42,23 @@ export class ShowHideExcludes {
     get userExcludes(): ExcludeOptions {
         let userExcludes = vscode.workspace.getConfiguration('files.exclude');
         let systemFiles: string[] = ['**/.DS_Store', '**/Thumbs.db'];
+        let defaultExcludes = this.defaultExcludes;
+
         let ignores: string[] = this.extensionConfig('ignoreExcludes') as string[];
         let excludes: ExcludeOptions = {};
-
+        let forceRemove = this.compareDefaultExcludes(defaultExcludes);
+        
+       
         for (const key in userExcludes) {
             if (userExcludes.hasOwnProperty(key) && !ignores.includes(key)) {
                 excludes[key] = userExcludes[key];
+            }
+        }
+
+        // Check if user excludes doesn't have the default exclude and if not add it
+        for (const key of this.defaultExcludes) {
+            if (!userExcludes.hasOwnProperty(key)) {
+                excludes[key] = false;
             }
         }
 
@@ -59,11 +70,45 @@ export class ShowHideExcludes {
             }
         }
 
+        // Remove files that were removed from the default exclude list
+        for(const file of forceRemove) {
+            if (excludes?.hasOwnProperty(file)) {
+                delete excludes[file];
+            }
+        }
+
         console.log('ignores', ignores);
+        console.log('defaultExcludes', defaultExcludes);
         console.log('userExcludes', userExcludes);
         console.log('excludes', excludes);
 
         return excludes;
+    }
+
+    get defaultExcludes() : string[] {
+        const machineConfig = vscode.workspace.getConfiguration();
+        return machineConfig.get('showHideExcludedConfig.exclude', []);
+    }
+
+    compareDefaultExcludes(excludes: string[]) {
+        const remove : string[] = [];
+
+        // Get the previously saved excluded list
+        const savedExcludes = this.storageGet('excludedList', []);
+
+        // Check if the new exclude list omits a previously excluded item
+        // If its missing, mark it for removal
+        savedExcludes.forEach((file: string) => {
+            if(excludes.includes(file) === false) {
+                remove.push(file);
+            }
+        });
+
+        // Update the excluded storage
+        this.storageSet('excludedList', excludes ?? []);
+
+        // Return the files to force remove from the exclude list
+        return remove;
     }
 
     toggle(): void {
@@ -79,11 +124,11 @@ export class ShowHideExcludes {
         this.updateStatusBar(status);
         vscode.commands.executeCommand('setContext', 'biati.excludedStatus', status);
 
-        // When hiding, if the user had no workspace excludes then
-        // simply delete the excludes from the workspace configuration
-        if (this.storageGet('hadEmptyWorkspaceExcludes')) {
-            this.resetWorkspaceExcludes();
-            return;
+        const existingWorkspaceExcludes = this.hasWorkspaceExcludes();
+        if (!existingWorkspaceExcludes) {
+            this.storageSet('hadEmptyWorkspaceExcludes', true);
+        } else {
+            this.storageSet('hadEmptyWorkspaceExcludes', false);
         }
 
         // If there were other excludes then update the exclude status
@@ -92,15 +137,16 @@ export class ShowHideExcludes {
 
 
     showExcludes(): void {
-        const existingWokspaceExcludes = this.hasWorkspaceExcludes();
-        if (!existingWokspaceExcludes) {
-            this.storageSet('hadEmptyWorkspaceExcludes', true);
+        // When hiding, if the user had no workspace excludes then
+        // simply delete the excludes from the workspace configuration
+        if (this.storageGet('hadEmptyWorkspaceExcludes')) {
+            console.log('reset!')
+            this.resetWorkspaceExcludes();
         } else {
-            this.storageSet('hadEmptyWorkspaceExcludes', false);
+            this.updateExcludes(this.updateExcludesValue('show'));
         }
 
         this.storageSet('excludedStatus', 'on');
-        this.updateExcludes(this.updateExcludesValue('show'));
         this.updateStatusBar('on');
         vscode.commands.executeCommand('setContext', 'biati.excludedStatus', 'on');
     }

--- a/src/showHideExcludes.ts
+++ b/src/showHideExcludes.ts
@@ -23,10 +23,20 @@ export class ShowHideExcludes {
         }
 
         vscode.workspace.onDidChangeConfiguration(event => {
-            let configUpdated: boolean = event.affectsConfiguration("showHideExcludedConfig");
+            const configUpdated: boolean = event.affectsConfiguration("showHideExcludedConfig");
             if (configUpdated) {
                 const statusBarVisible = this.extensionConfig('showStatusBar');
                 statusBarVisible ? this.statusBar.show() : this.statusBar.hide();
+            }
+
+            const excludeUpdated: boolean = event.affectsConfiguration("showHideExcludedConfig.exclude");
+            if(excludeUpdated) {
+                // Force update the hidden list
+                if(this.excludeIsHidden) {
+                    this.hideExcludes();
+                } else {
+                    this.showExcludes();
+                }
             }
         });
     }


### PR DESCRIPTION
This seemingly works for my needs. 

Quick video demonstrating the functionality:
https://www.youtube.com/watch?v=jZTOWHRG3aA

`showHideExcludedConfig.exclude` is an optional setting which is an array of strings describing the regex of files to exclude. Example:

```
showHideExcludedConfig.exclude: [
    "**/.git*",
   "**/node_modules",
]
```

When this array is defined and the toggle button is pressed, it is used to add the item to `files.exclude` setting. This list is static so it does not get changed by the extension, making it safe to add to configuration files that are checked into git. 

Any items manually defined in `files.exclude` are preserved, unless its also defined in `showHideExcludedConfig.exclude`. Without defining `showHideExcludedConfig.exclude` it will work exactly as it does now.

I added in a mechanism to store the list everytime the button is pressed. This allows for a comparison to be done to see if any items where removed from `showHideExcludedConfig.exclude` and can reflect that in `files.exclude`. For example, if you remove `"**/.git*"` from the list, on the next visibility change, it will automatically remove it from `files.exclude`. This allows for the state to be reflected if its version controlled without users needing to manually remove it from `settings.json`.

When updating `showHideExcludedConfig.exclude` it automatically triggers an update to `files.exclude`.

# Things to review
### Remote Containers
This also works in a devcontainer, but I'm still a bit iffy on how the workspace.getConfiguration all works. If you define `showHideExcludedConfig.exclude` in both `settings.json` and `.devcontainer.json` I'm not sure which takes priority. Really I'd like it to scan both files, but I haven't been able to find documentation on how to pull settings directly from the remote config.

### Resetting workspace excludes
In my testing I did find that it seemed like the `hadEmptyWorkspaceExcludes` was backwards so I flipped it. In the current version when toggling hidden, it would delete the list, and toggling visible would add all the items with "false". I now call `resetWorkspaceExcludes` from when calling `showExcludes`. To me this makes more sense as I'd expect the list to be empty showing and populated when hidden.

Closes #1 